### PR TITLE
disable cudnn.benchmark

### DIFF
--- a/motiondiff_modules/spectre/src/spectre.py
+++ b/motiondiff_modules/spectre/src/spectre.py
@@ -25,7 +25,7 @@ from .models.FLAME import FLAME, FLAMETex
 from .utils import util
 from .utils.tensor_cropper import transform_points
 from skimage.io import imread
-torch.backends.cudnn.benchmark = True
+#torch.backends.cudnn.benchmark = True
 import numpy as np
 
 def recursive_to(x, target):


### PR DESCRIPTION
Importing SPECTRE causes cudnn.benchmark be turned on, which slows everything down in whole Comfy